### PR TITLE
(#285) Ability to purge nrpe.d directory of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ Hash of plugins to be passed to nrpe::plugin with create_resources().
 
 - *Default*: undef
 
+purge_plugins
+-------------
+Boolean to purge the nrpe.d directory of entries not managed by Puppet.
+
+- *Default*: false
+
 ===
 
 # Define `nrpe::plugin`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class nrpe (
   $service_name                     = 'nrpe',
   $service_enable                   = true,
   $plugins                          = undef,
+  $purge_plugins                    = false,
 ) {
 
   # OS platform defaults
@@ -166,6 +167,12 @@ class nrpe (
     $service_enable_bool = $service_enable
   }
 
+  if type($purge_plugins) == 'string' {
+    $purge_plugins_bool = str2bool($purge_plugins)
+  } else {
+    $purge_plugins_bool = $purge_plugins
+  }
+
   # Validate params
   validate_re($nrpe_config_mode, '^\d{4}$',
     "nrpe::nrpe_config_mode must be a four digit octal mode. Detected value is <${nrpe_config_mode}>.")
@@ -226,6 +233,8 @@ class nrpe (
     owner   => $nrpe_config_owner,
     group   => $nrpe_config_group,
     mode    => $nrpe_config_mode,
+    purge   => $purge_plugins_bool,
+    recurse => true,
     require => Package['nrpe_package'],
     notify  => Service['nrpe_service'],
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -76,6 +76,8 @@ describe 'nrpe' do
         'owner'   => 'root',
         'group'   => 'root',
         'mode'    => '0644',
+        'purge'   => 'false',
+        'recurse' => 'true',
         'require' => 'Package[nrpe_package]',
         'notify'  => 'Service[nrpe_service]',
       })
@@ -723,6 +725,47 @@ describe 'nrpe' do
       expect {
         should contain_class('nrpe')
       }.to raise_error(Puppet::Error)
+    end
+  end
+
+  context 'with purge_plugins specified as not close to a boolean' do
+    let(:params) { { :purge_plugins => 'not even close to a boolean' } }
+    let(:facts) do
+      { :osfamily          => 'RedHat',
+        :lsbmajdistrelease => '6',
+      }
+    end
+
+    it do
+      expect {
+        should contain_class('nrpe')
+      }.to raise_error(Puppet::Error)
+    end
+  end
+
+
+  ['true',true,'false',false].each do |value|
+    context "with purge_plugins specified as #{value}" do
+      let(:params) { { :purge_plugins => value } }
+      let(:facts) do
+        { :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '6',
+        }
+      end
+
+      it {
+        should contain_file('nrpe_config_dot_d').with({
+          'ensure'  => 'directory',
+          'path'    => '/etc/nrpe.d',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'purge'   => value,
+          'recurse' => 'true',
+          'require' => 'Package[nrpe_package]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
     end
   end
 end


### PR DESCRIPTION
This allows you to purge non puppet managed files from the nrpe.d
directory. The default is false.
