### PR TITLE
Change default pid location for linux

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class nrpe (
       $default_nagios_plugins_package_adminfile = undef
       $default_nagios_plugins_package_source    = undef
       $default_nrpe_config                      = '/etc/nagios/nrpe.cfg'
-      $default_pid_file                         = '/var/run/nrpe/nrpe.pid'
+      $default_pid_file                         = '/var/run/nrpe.pid'
       $default_nrpe_user                        = 'nrpe'
       $default_nrpe_group                       = 'nrpe'
       $default_include_dir                      = '/etc/nrpe.d'
@@ -70,7 +70,7 @@ class nrpe (
       $default_nagios_plugins_package_source    = undef
       $default_nrpe_config                      = '/etc/nagios/nrpe.cfg'
       $default_libexecdir                       = '/usr/lib/nagios/plugins'
-      $default_pid_file                         = '/var/run/nrpe/nrpe.pid'
+      $default_pid_file                         = '/var/run/nrpe.pid'
       $default_nrpe_user                        = 'nagios'
       $default_nrpe_group                       = 'nagios'
       $default_include_dir                      = '/etc/nrpe.d'
@@ -103,7 +103,7 @@ class nrpe (
           $default_nagios_plugins_package_source    = undef
           $default_nrpe_config                      = '/etc/nagios/nrpe.cfg'
           $default_libexecdir                       = '/usr/lib/nagios/plugins'
-          $default_pid_file                         = '/var/run/nagios/nrpe.pid'
+          $default_pid_file                         = '/var/run/nrpe.pid'
           $default_nrpe_user                        = 'nagios'
           $default_nrpe_group                       = 'nagios'
           $default_include_dir                      = '/etc/nagios/nrpe.d'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -51,7 +51,7 @@ describe 'nrpe' do
     }
 
     it { should contain_file('nrpe_config').with_content(/^log_facility=daemon$/) }
-    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nrpe\/nrpe.pid$/) }
+    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nrpe.pid$/) }
     it { should contain_file('nrpe_config').with_content(/^server_port=5666$/) }
     it { should_not contain_file('nrpe_config').with_content(/^server_address=127.0.0.1$/) }
     it { should contain_file('nrpe_config').with_content(/^nrpe_user=nrpe$/) }
@@ -131,7 +131,7 @@ describe 'nrpe' do
     }
 
     it { should contain_file('nrpe_config').with_content(/^log_facility=daemon$/) }
-    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nrpe\/nrpe.pid$/) }
+    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nrpe.pid$/) }
     it { should contain_file('nrpe_config').with_content(/^server_port=5666$/) }
     it { should_not contain_file('nrpe_config').with_content(/^server_address=127.0.0.1$/) }
     it { should contain_file('nrpe_config').with_content(/^nrpe_user=nagios$/) }
@@ -213,7 +213,7 @@ describe 'nrpe' do
     }
 
     it { should contain_file('nrpe_config').with_content(/^log_facility=daemon$/) }
-    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nagios\/nrpe.pid$/) }
+    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nrpe.pid$/) }
     it { should contain_file('nrpe_config').with_content(/^server_port=5666$/) }
     it { should_not contain_file('nrpe_config').with_content(/^server_address=127.0.0.1$/) }
     it { should contain_file('nrpe_config').with_content(/^nrpe_user=nagios$/) }


### PR DESCRIPTION
RedHat dosn't support /var/run/nrpe/nrpe.pid since it uses /etc/init.d/functions
