### PR TITLE
Add Solaris 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - PUPPET_GEM_VERSION="~> 4.1.0"
     - PUPPET_GEM_VERSION="~> 4.2.0"
     - PUPPET_GEM_VERSION="~> 4.3.0"
+    - PUPPET_GEM_VERSION="~> 4.4.0"
     - PUPPET_GEM_VERSION="~> 4"
     - PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
 
@@ -50,6 +51,8 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 4.2.0"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4.3.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.4.0"
     - rvm: 1.8.7
       env: PUPPET_GEM_VERSION="~> 4"
     - rvm: 1.8.7

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,9 @@ gem 'puppet-lint-undef_in_function-check'
 gem 'puppet-lint-unquoted_string-check'
 gem 'puppet-lint-variable_contains_upcase'
 
-# rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  # rspec must be v2 for ruby 1.8.7
   gem 'rspec', '~> 2.0'
+  # rake >= 11 does not support ruby 1.8.7
+  gem 'rake', '~> 10.0'
 end

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It is tested on the following platforms.
 * EL 6
 * Suse 11
 * Solaris 10
+* Solaris 11
 * Ubuntu 12
 
 ===
@@ -51,6 +52,12 @@ nrpe_package_source
 Source to NRPE package.
 
 - *Default*: based on OS platform. (used on Solaris)
+
+nrpe_package_provider
+-------------------
+Name of the package provider for the NRPE package.
+
+- *Default*: undef.
 
 nagios_plugins_package
 ----------------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@ class nrpe (
   $plugins                          = undef,
   $purge_plugins                    = false,
   $hiera_merge_plugins              = false,
+  $nrpe_package_provider            = undef,
 ) {
 
   # OS platform defaults
@@ -289,6 +290,13 @@ class nrpe (
   validate_absolute_path($include_dir_real)
   validate_re($service_ensure, '^(running|stopped)$',
     "nrpe::service_ensure must be \'running\' or \'stopped\'. Detected value is <${service_ensure}>.")
+
+  if $nrpe_package_provider != undef {
+    validate_string($nrpe_package_provider)
+    Package {
+      provider => $nrpe_package_provider,
+    }
+  }
 
   package { $nrpe_package_real:
     ensure    => $nrpe_package_ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ghoneycutt-nrpe",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "ghoneycutt",
   "summary": "Manage NRPE",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,5 +1,13 @@
 require 'spec_helper'
 describe 'nrpe' do
+  # setting the global facts for all test if not overwritten locally
+  let(:facts) do
+    {
+      :osfamily          => 'RedHat',
+      :lsbmajdistrelease => '6',
+      :architecture      => 'x86_64',
+    }
+  end
 
   context 'with default options on unsupported osfamily' do
     let(:facts) { { :osfamily => 'Unsupported' } }
@@ -12,11 +20,6 @@ describe 'nrpe' do
   end
 
   context 'with default options on EL 6' do
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it { should compile.with_all_deps }
 
@@ -332,11 +335,6 @@ describe 'nrpe' do
 
   context 'with nrpe_config set to a non absolute path' do
     let(:params) { { :nrpe_config => 'invalid/path' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -347,11 +345,6 @@ describe 'nrpe' do
 
   context 'with nrpe_config_mode set to an invalid value' do
     let(:params) { { :nrpe_config_mode => '666' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -439,11 +432,6 @@ describe 'nrpe' do
 
   context 'with libexecdir set to a non absolute path' do
     let(:params) { { :libexecdir => 'invalid/path' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -454,11 +442,6 @@ describe 'nrpe' do
 
   context 'with pid_file set to a non absolute path' do
     let(:params) { { :pid_file => 'invalid/path' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -469,11 +452,6 @@ describe 'nrpe' do
 
   context 'with server_port set to an invalid setting (non-digit)' do
     let(:params) { { :server_port => 'not_a_port' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -484,11 +462,6 @@ describe 'nrpe' do
 
   context 'with server_port set to a valid digit, but invalid port number (above 65535)' do
     let(:params) { { :server_port => 1000000 } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -499,11 +472,6 @@ describe 'nrpe' do
 
   context 'with server_port set to a valid digit, but invalid port number (negative)' do
     let(:params) { { :server_port => -23 } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -514,22 +482,12 @@ describe 'nrpe' do
 
   context 'with server_port set to a valid port, but stringified' do
     let(:params) { { :server_port => '1234' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it { should contain_file('nrpe_config').with_content(/^server_port=1234$/) }
   end
 
   context 'with server_address_enable set to true' do
     let(:params) { { :server_address_enable => true  } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it { should compile.with_all_deps }
 
@@ -538,11 +496,6 @@ describe 'nrpe' do
 
   context 'with server_address_enable set to to stringified \'true\'' do
     let(:params) { { :server_address_enable => 'true' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it { should compile.with_all_deps }
 
@@ -551,11 +504,6 @@ describe 'nrpe' do
 
   context 'with multiple entries for allowed_hosts' do
     let(:params) { { :allowed_hosts => ['127.0.0.1', 'poller.example.com'] } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it { should compile.with_all_deps }
 
@@ -564,11 +512,6 @@ describe 'nrpe' do
 
   context 'with allowed_hosts set to an invalid type (non-array)' do
     let(:params) { { :allowed_hosts => 'not_an_array' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -579,11 +522,6 @@ describe 'nrpe' do
 
   context 'with dont_blame_nrpe set to invalid value' do
     let(:params) { { :dont_blame_nrpe => '2' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -594,11 +532,6 @@ describe 'nrpe' do
 
   context 'with allow_bash_command_substitution set to invalid value' do
     let(:params) { { :allow_bash_command_substitution => '2' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -609,11 +542,6 @@ describe 'nrpe' do
 
   context 'with command_prefix_enable set to true' do
     let(:params) { { :command_prefix_enable => true  } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it { should compile.with_all_deps }
 
@@ -622,11 +550,6 @@ describe 'nrpe' do
 
   context 'with command_prefix_enable set to to stringified \'true\'' do
     let(:params) { { :command_prefix_enable => 'true' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it { should compile.with_all_deps }
 
@@ -635,11 +558,6 @@ describe 'nrpe' do
 
   context 'with command_prefix set to a non absolute path' do
     let(:params) { { :command_prefix => 'invalid/path' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -650,11 +568,6 @@ describe 'nrpe' do
 
   context 'with debug set to invalid value' do
     let(:params) { { :debug => '2' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -665,11 +578,6 @@ describe 'nrpe' do
 
   context 'with command_timeout set to an invalid setting' do
     let(:params) { { :command_timeout => '-1' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -680,11 +588,6 @@ describe 'nrpe' do
 
   context 'with connection_timeout set to an invalid setting' do
     let(:params) { { :connection_timeout => '-1' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -695,11 +598,6 @@ describe 'nrpe' do
 
   context 'with allow_weak_random_seed set to invalid value' do
     let(:params) { { :allow_weak_random_seed => '2' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -710,11 +608,6 @@ describe 'nrpe' do
 
   context 'with include_dir set to invalid value' do
     let(:params) { { :include_dir => 'invalid/path' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -725,11 +618,6 @@ describe 'nrpe' do
 
   context 'with service_ensure set to invalid value' do
     let(:params) { { :service_ensure => 'present' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -740,11 +628,6 @@ describe 'nrpe' do
 
   context 'with service_enable set to invalid value' do
     let(:params) { { :service_enable => 'invalid' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -1209,11 +1092,6 @@ describe 'nrpe' do
 
   context 'with plugins specified as an invalid type (array)' do
     let(:params) { { :plugins => ['an','array'] } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it do
       expect {
@@ -1224,11 +1102,6 @@ describe 'nrpe' do
 
   context 'with purge_plugins specified as not close to a boolean' do
     let(:params) { { :purge_plugins => 'not even close to a boolean' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it do
       expect {
@@ -1241,11 +1114,6 @@ describe 'nrpe' do
   ['true',true,'false',false].each do |value|
     context "with purge_plugins specified as #{value}" do
       let(:params) { { :purge_plugins => value } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it {
         should contain_file('nrpe_config_dot_d').with({
@@ -1265,11 +1133,6 @@ describe 'nrpe' do
 
   context 'with hiera_merge_plugins specified as not close to a boolean' do
     let(:params) { { :hiera_merge_plugins => 'not even close to a boolean' } }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it do
       expect {
@@ -1281,11 +1144,6 @@ describe 'nrpe' do
   ['true',true,'false',false].each do |value|
     context "with hiera_merge_plugins specified as #{value}" do
       let(:params) { { :hiera_merge_plugins => value } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it { should compile.with_all_deps }
     end
@@ -1294,11 +1152,6 @@ describe 'nrpe' do
   describe 'with nrpe_package parameter' do
     context 'set to a string' do
       let(:params) { { :nrpe_package => 'mynrpe' } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it {
         should contain_package('mynrpe').with({
@@ -1311,11 +1164,6 @@ describe 'nrpe' do
 
     context 'set to an array' do
       let(:params) { { :nrpe_package => ['mynrpe','nrpe_dep'] } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it {
         should contain_package('mynrpe').with({
@@ -1336,11 +1184,6 @@ describe 'nrpe' do
 
     context 'set to an invalid type (boolean)' do
       let(:params) { { :nrpe_package => true } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it do
         expect {
@@ -1353,11 +1196,6 @@ describe 'nrpe' do
   describe 'with nrpe_package_ensure parameter' do
     context 'set to a string' do
       let(:params) { { :nrpe_package_ensure => 'latest' } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it {
         should contain_package('nrpe').with({
@@ -1368,11 +1206,6 @@ describe 'nrpe' do
 
     context 'set to an invalid type (boolean)' do
       let(:params) { { :nrpe_package_ensure => true } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it do
         expect {
@@ -1385,11 +1218,6 @@ describe 'nrpe' do
   describe 'with nagios_plugins_package parameter' do
     context 'set to a string' do
       let(:params) { { :nagios_plugins_package => 'nagios-plugins' } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it {
         should contain_package('nagios-plugins').with({
@@ -1402,11 +1230,6 @@ describe 'nrpe' do
 
     context 'set to an array' do
       let(:params) { { :nagios_plugins_package => ['nagios-plugins','nagios-plugins-dep'] } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it {
         should contain_package('nagios-plugins').with({
@@ -1427,11 +1250,6 @@ describe 'nrpe' do
 
     context 'set to an invalid type (boolean)' do
       let(:params) { { :nagios_plugins_package => true } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it do
         expect {
@@ -1444,11 +1262,6 @@ describe 'nrpe' do
   describe 'with nagios_plugins_package_ensure parameter' do
     context 'set to a string' do
       let(:params) { { :nagios_plugins_package_ensure => 'latest' } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it {
         should contain_package('nagios-plugins').with({
@@ -1459,11 +1272,6 @@ describe 'nrpe' do
 
     context 'set to an invalid type (boolean)' do
       let(:params) { { :nagios_plugins_package_ensure => true } }
-      let(:facts) do
-        { :osfamily          => 'RedHat',
-          :lsbmajdistrelease => '6',
-        }
-      end
 
       it do
         expect {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -363,7 +363,6 @@ describe 'nrpe' do
   context 'with default options on Solaris' do
     let(:facts) do
       { :osfamily          => 'Solaris',
-        :kernelrelase      => '5.10',
       }
     end
 
@@ -437,6 +436,7 @@ describe 'nrpe' do
       })
     }
   end
+
   context 'with libexecdir set to a non absolute path' do
     let(:params) { { :libexecdir => 'invalid/path' } }
     let(:facts) do
@@ -1471,5 +1471,42 @@ describe 'nrpe' do
         }.to raise_error(Puppet::Error,/true is not a string\./)
       end
     end
+
+    describe 'with nrpe_package_provider parameter' do
+      context 'set to a valid string' do
+        let :params do
+          { 
+            :nrpe_package_provider  => 'sun',
+          }
+        end
+ 
+        it {
+          should contain_package('nrpe').with({
+            'provider' => 'sun',
+          })
+        }
+
+        it {
+          should contain_package('nagios-plugins').with({
+            'provider' => 'sun',
+          })
+        }
+      end
+
+      context 'set to an invalid type (non-string)' do
+        let :params do
+          { :nrpe_package           => 'nrpe',
+            :nrpe_package_provider  => true,
+          }
+        end
+
+        it 'should fail' do
+          expect {
+            should contain_class('nrpe')
+          }.to raise_error(Puppet::Error,/true is not a string.  It looks to be a TrueClass/)
+        end
+      end
+    end
+
   end
 end

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe 'nrpe::plugin' do
+  # setting the global facts for all test if not overwritten locally
+  let(:facts) do
+    {
+      :osfamily          => 'RedHat',
+      :lsbmajdistrelease => '6',
+      :architecture      => 'x86_64',
+    }
+  end
   context 'should create plugin file with all options specified' do
     let(:title) { 'check_root_partition' }
     let(:params) do
       { :plugin     => 'check_disk',
         :libexecdir => '/usr/lib64/nagios/plugins',
         :args       => '-w 20% -c 10% -p /',
-      }
-    end
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
       }
     end
 
@@ -46,11 +49,6 @@ describe 'nrpe::plugin' do
         :args       => '-w 20% -c 10% -p /',
       }
     end
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it { should compile.with_all_deps }
 
@@ -71,11 +69,6 @@ describe 'nrpe::plugin' do
 
   context 'should create plugin file with no args param specified' do
     let(:title) { 'check_load' }
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it { should compile.with_all_deps }
 
@@ -112,11 +105,6 @@ describe 'nrpe::plugin' do
         :args   => '-w 20% -c 10% -p /',
       }
     end
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
-      }
-    end
 
     it 'should fail' do
       expect {
@@ -131,11 +119,6 @@ describe 'nrpe::plugin' do
       { :plugin     => 'check_disk',
         :libexecdir => 'invalid/path',
         :args       => '-w 20% -c 10% -p /',
-      }
-    end
-    let(:facts) do
-      { :osfamily          => 'RedHat',
-        :lsbmajdistrelease => '6',
       }
     end
 


### PR DESCRIPTION
Add Solaris 11 support.
The default Solaris 11 package provider (pkg) expects packages to be configured from the repository. This change also allows the legacy installation method ('sun' package provider)  to be used by specifying the package source and the admin file. 