### PR TITLE
Make pid file optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The syslog facility that should be used for logging purposes.
 
 pid_file
 --------
-File in which the NRPE daemon should write it's process ID number.
+File in which the NRPE daemon should write it's process ID number. To disable the use of the pid_file parameter, specify the value as 'absent'.
 
 - *Default*: based on OS platform.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -263,7 +263,9 @@ class nrpe (
     "nrpe::nrpe_config_mode must be a four digit octal mode. Detected value is <${nrpe_config_mode}>.")
   validate_absolute_path($nrpe_config_real)
   validate_absolute_path($libexecdir_real)
-  validate_absolute_path($pid_file_real)
+  if $pid_file_real != 'absent' {
+    validate_absolute_path($pid_file_real)
+  }
 
   if is_string($server_port) == true {
     validate_re($server_port, '^\d+$',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -440,16 +440,6 @@ describe 'nrpe' do
     end
   end
 
-  context 'with pid_file set to a non absolute path' do
-    let(:params) { { :pid_file => 'invalid/path' } }
-
-    it 'should fail' do
-      expect {
-        should contain_class('nrpe')
-      }.to raise_error(Puppet::Error)
-    end
-  end
-
   context 'with server_port set to an invalid setting (non-digit)' do
     let(:params) { { :server_port => 'not_a_port' } }
 
@@ -1313,6 +1303,27 @@ describe 'nrpe' do
             should contain_class('nrpe')
           }.to raise_error(Puppet::Error,/true is not a string.  It looks to be a TrueClass/)
         end
+      end
+    end
+
+  end
+
+  describe 'with pid_file parameter' do
+    context 'with pid_file set to absent' do
+      let(:params) { { :pid_file => 'absent' } }
+
+      it {
+        should contain_file('nrpe_config').without_content(/^\s*pid_file/)
+      }
+    end
+
+    context 'with pid_file set to a non absolute path' do
+      let(:params) { { :pid_file => 'invalid/path' } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('nrpe')
+        }.to raise_error(Puppet::Error,/"invalid\/path" is not an absolute path\./)
       end
     end
 

--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -21,7 +21,9 @@ log_facility=<%= @log_facility %>
 # The name of the file in which the NRPE daemon should write it's process ID
 # number.  The file is only written if the NRPE daemon is started by the root
 # user and is running in standalone mode.
+<% if @pid_file_real != 'absent' -%>
 pid_file=<%= @pid_file_real %>
+<% end -%>
 
 # PORT NUMBER
 # Port number we should wait for connections on.


### PR DESCRIPTION
On some systems pid file is not always necessary.On Solaris /var/run is
a temporary file system whose contents are deleted on reboot meaning service
start/restart will report errors without the pid file