### PR TITLE
Added support for consolidation of all rules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ else
 end
 
 gem 'metadata-json-lint'
-gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'puppetlabs_spec_helper', '>= 1.1.1'
 gem 'facter', '>= 1.7.0'
 gem 'rspec-puppet'
-gem 'puppet-lint', :git => 'https://github.com/rodjek/puppet-lint.git'
+gem 'puppet-lint', '>= 1.0', '< 3.0'
 gem 'puppet-lint-absolute_classname-check'
 gem 'puppet-lint-alias-check'
 gem 'puppet-lint-empty_string-check'
@@ -30,3 +30,9 @@ if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   # rake >= 11 does not support ruby 1.8.7
   gem 'rake', '~> 10.0'
 end
+
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '2.0'
+  gem 'json', '~> 1.0'
+  gem 'json_pure', '~> 1.0'
+end
+

--- a/README.md
+++ b/README.md
@@ -253,6 +253,18 @@ Boolean to purge the nrpe.d directory of entries not managed by Puppet.
 
 - *Default*: false
 
+plugins_consolidate
+-------------------
+Boolean to consolidate all plugins into one file under nrpe.d instead of one file for each plugin.
+
+- *Default*: false
+
+plugins_consolidate_filename
+----------------------------
+Filename to use when plugins_consolidate is set to true. Should be specified without file extension.
+
+- *Default*: 'plugins'
+
 ===
 
 # Define `nrpe::plugin`

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -627,23 +627,6 @@ describe 'nrpe' do
   end
 
   context 'with plugins specified as a hash on 32 bit EL 6' do
-    let(:params) {
-      {
-        :plugins => {
-          'check_root_partition' => {
-            'plugin'     => 'check_disk',
-            'libexecdir' => '/usr/lib/nagios/plugins',
-            'args'       => '-w 20% -c 10% -p /',
-          },
-          'check_load' => {
-            'args' => '-w 10,8,8 -c 12,10,9',
-          },
-          'check_me_out' => {
-            'ensure' => 'absent',
-          },
-        }
-      }
-    }
     let(:facts) do
       { :architecture      => 'i386',
         :osfamily          => 'RedHat',
@@ -651,75 +634,125 @@ describe 'nrpe' do
       }
     end
 
-    it { should compile.with_all_deps }
+    context 'with plugins_consolidate set to false (default)' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'false',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
 
-    it { should contain_class('nrpe') }
+      it { should compile.with_all_deps }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nrpe.d/check_root_partition.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it { should contain_class('nrpe') }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition') \
-        .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nrpe.d/check_root_partition.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nrpe.d/check_load.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load') \
-        .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nrpe.d/check_load.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_me_out').with({
-        'ensure'  => 'absent',
-        'path'    => '/etc/nrpe.d/check_me_out.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load') \
+          .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
+      }
+
+      it {
+        should contain_file('nrpe_plugin_check_me_out').with({
+          'ensure'  => 'absent',
+          'path'    => '/etc/nrpe.d/check_me_out.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+    end
+
+    context 'with plugins_consolidate set to true' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'true',
+          :plugins_consolidate_filename => 'baseline',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('nrpe') }
+
+      it {
+        should contain_file('baseline').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nrpe.d/baseline.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+
+      it {
+        should contain_file('baseline') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/) \
+          .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/) \
+          .without_content(/command\[check_me_out\]/)
+      }
+
+    end
   end
 
   context 'with plugins specified as a hash on 64 bit EL 6' do
-    let(:params) {
-      {
-        :plugins => {
-          'check_root_partition' => {
-            'plugin'     => 'check_disk',
-            'libexecdir' => '/usr/lib64/nagios/plugins',
-            'args'       => '-w 20% -c 10% -p /',
-          },
-          'check_load' => {
-            'args' => '-w 10,8,8 -c 12,10,9',
-          },
-          'check_me_out' => {
-            'ensure' => 'absent',
-          },
-        }
-      }
-    }
     let(:facts) do
       { :architecture      => 'x86_64',
         :osfamily          => 'RedHat',
@@ -727,150 +760,250 @@ describe 'nrpe' do
       }
     end
 
-    it { should compile.with_all_deps }
+    context 'with plugins_consolidate set to false (default)' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'false',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib64/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
 
-    it { should contain_class('nrpe') }
+      it { should compile.with_all_deps }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nrpe.d/check_root_partition.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it { should contain_class('nrpe') }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition') \
-        .with_content(/^command\[check_root_partition\]=\/usr\/lib64\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nrpe.d/check_root_partition.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nrpe.d/check_load.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib64\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load') \
-        .with_content(/^command\[check_load\]=\/usr\/lib64\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nrpe.d/check_load.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_me_out').with({
-        'ensure'  => 'absent',
-        'path'    => '/etc/nrpe.d/check_me_out.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load') \
+          .with_content(/^command\[check_load\]=\/usr\/lib64\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
+      }
+
+      it {
+        should contain_file('nrpe_plugin_check_me_out').with({
+          'ensure'  => 'absent',
+          'path'    => '/etc/nrpe.d/check_me_out.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+    end
+
+    context 'with plugins_consolidate set to true' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'true',
+          :plugins_consolidate_filename => 'baseline',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib64/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('nrpe') }
+
+      it {
+        should contain_file('baseline').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nrpe.d/baseline.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+
+      it {
+        should contain_file('baseline') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib64\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/) \
+          .with_content(/^command\[check_load\]=\/usr\/lib64\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/) \
+          .without_content(/command\[check_me_out\]/)
+      }
+
+    end
   end
 
   context 'with plugins specified as a hash on Suse 11' do
-    let(:params) {
-      {
-        :plugins => {
-          'check_root_partition' => {
-            'plugin'     => 'check_disk',
-            'libexecdir' => '/usr/lib/nagios/plugins',
-            'args'       => '-w 20% -c 10% -p /',
-          },
-          'check_load' => {
-            'args' => '-w 10,8,8 -c 12,10,9',
-          },
-          'check_me_out' => {
-            'ensure' => 'absent',
-          },
-        }
-      }
-    }
     let(:facts) do
       { :osfamily          => 'Suse',
         :lsbmajdistrelease => '11',
       }
     end
 
-    it { should compile.with_all_deps }
+    context 'with plugins_consolidate set to false (default)' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'false',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
 
-    it { should contain_class('nrpe') }
+      it { should compile.with_all_deps }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nrpe.d/check_root_partition.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it { should contain_class('nrpe') }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition') \
-        .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nrpe.d/check_root_partition.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nrpe.d/check_load.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load') \
-        .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nrpe.d/check_load.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_me_out').with({
-        'ensure'  => 'absent',
-        'path'    => '/etc/nrpe.d/check_me_out.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load') \
+          .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
+      }
+
+      it {
+        should contain_file('nrpe_plugin_check_me_out').with({
+          'ensure'  => 'absent',
+          'path'    => '/etc/nrpe.d/check_me_out.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+    end
+
+    context 'with plugins_consolidate set to true' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'true',
+          :plugins_consolidate_filename => 'baseline',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('nrpe') }
+
+      it {
+        should contain_file('baseline').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nrpe.d/baseline.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+
+      it {
+        should contain_file('baseline') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/) \
+          .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/) \
+          .without_content(/command\[check_me_out\]/)
+      }
+
+    end
   end
   
   context 'with plugins specified as a hash on Debian 6' do
-    let(:params) {
-      {
-        :plugins => {
-          'check_root_partition' => {
-            'plugin'     => 'check_disk',
-            'libexecdir' => '/usr/lib/nagios/plugins',
-            'args'       => '-w 20% -c 10% -p /',
-          },
-          'check_load' => {
-            'args'       => '-w 10,8,8 -c 12,10,9',
-          },
-          'check_me_out' => {
-            'ensure' => 'absent',
-          },
-        }
-      }
-    }
     let(:facts) do
       { :osfamily          => 'Debian',
         :lsbdistid         => 'Debian',
@@ -878,75 +1011,125 @@ describe 'nrpe' do
       }
     end
 
-    it { should compile.with_all_deps }
+    context 'with plugins_consolidate set to false (default)' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'false',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args'       => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
 
-    it { should contain_class('nrpe') }
+      it { should compile.with_all_deps }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nagios/nrpe.d/check_root_partition.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it { should contain_class('nrpe') }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition') \
-        .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nagios/nrpe.d/check_root_partition.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nagios/nrpe.d/check_load.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load') \
-        .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nagios/nrpe.d/check_load.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_me_out').with({
-        'ensure'  => 'absent',
-        'path'    => '/etc/nagios/nrpe.d/check_me_out.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load') \
+          .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
+      }
+
+      it {
+        should contain_file('nrpe_plugin_check_me_out').with({
+          'ensure'  => 'absent',
+          'path'    => '/etc/nagios/nrpe.d/check_me_out.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+    end
+
+    context 'with plugins_consolidate set to true' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'true',
+          :plugins_consolidate_filename => 'baseline',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('nrpe') }
+
+      it {
+        should contain_file('baseline').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nagios/nrpe.d/baseline.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+
+      it {
+        should contain_file('baseline') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/) \
+          .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/) \
+          .without_content(/command\[check_me_out\]/)
+      }
+
+    end
   end
 
   context 'with plugins specified as a hash on Ubuntu 12' do
-    let(:params) {
-      {
-        :plugins => {
-          'check_root_partition' => {
-            'plugin'     => 'check_disk',
-            'libexecdir' => '/usr/lib/nagios/plugins',
-            'args'       => '-w 20% -c 10% -p /',
-          },
-          'check_load' => {
-            'args'       => '-w 10,8,8 -c 12,10,9',
-          },
-          'check_me_out' => {
-            'ensure' => 'absent',
-          },
-        }
-      }
-    }
     let(:facts) do
       { :osfamily          => 'Debian',
         :lsbdistid         => 'Ubuntu',
@@ -954,130 +1137,248 @@ describe 'nrpe' do
       }
     end
 
-    it { should compile.with_all_deps }
+    context 'with plugins_consolidate set to false (default)' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'false',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args'       => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
 
-    it { should contain_class('nrpe') }
+      it { should compile.with_all_deps }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nagios/nrpe.d/check_root_partition.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it { should contain_class('nrpe') }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition') \
-        .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nagios/nrpe.d/check_root_partition.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load').with({
-        'ensure'  => 'file',
-        'path'    => '/etc/nagios/nrpe.d/check_load.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load') \
-        .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nagios/nrpe.d/check_load.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_me_out').with({
-        'ensure'  => 'absent',
-        'path'    => '/etc/nagios/nrpe.d/check_me_out.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load') \
+          .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
+      }
+
+      it {
+        should contain_file('nrpe_plugin_check_me_out').with({
+          'ensure'  => 'absent',
+          'path'    => '/etc/nagios/nrpe.d/check_me_out.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+
+    end
+
+    context 'with plugins_consolidate set to true' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'true',
+          :plugins_consolidate_filename => 'baseline',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/lib/nagios/plugins',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('nrpe') }
+
+      it {
+        should contain_file('baseline').with({
+          'ensure'  => 'file',
+          'path'    => '/etc/nagios/nrpe.d/baseline.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+
+      it {
+        should contain_file('baseline') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/) \
+          .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/) \
+          .without_content(/command\[check_me_out\]/)
+      }
+
+    end
   end
 
   context 'with plugins specified as a hash on Solaris 10' do
-    let(:params) {
-      {
-        :plugins => {
-          'check_root_partition' => {
-            'plugin'     => 'check_disk',
-            'libexecdir' => '/usr/local/nagios/libexec',
-            'args'       => '-w 20% -c 10% -p /',
-          },
-          'check_load' => {
-            'args' => '-w 10,8,8 -c 12,10,9',
-          },
-          'check_me_out' => {
-            'ensure' => 'absent',
-          },
-        }
-      }
-    }
     let(:facts) do
       { :osfamily      => 'Solaris',
         :kernelrelease => '5.10',
       }
     end
 
-    it { should compile.with_all_deps }
+    context 'with plugins_consolidate set to false (default)' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'false',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/local/nagios/libexec',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
 
-    it { should contain_class('nrpe') }
+      it { should compile.with_all_deps }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition').with({
-        'ensure'  => 'file',
-        'path'    => '/usr/local/nagios/etc/nrpe.d/check_root_partition.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it { should contain_class('nrpe') }
 
-    it {
-      should contain_file('nrpe_plugin_check_root_partition') \
-        .with_content(/^command\[check_root_partition\]=\/usr\/local\/nagios\/libexec\/check_disk -w 20% -c 10% -p \/$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition').with({
+          'ensure'  => 'file',
+          'path'    => '/usr/local/nagios/etc/nrpe.d/check_root_partition.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load').with({
-        'ensure'  => 'file',
-        'path'    => '/usr/local/nagios/etc/nrpe.d/check_load.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_root_partition') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/local\/nagios\/libexec\/check_disk -w 20% -c 10% -p \/$/)
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_load') \
-        .with_content(/^command\[check_load\]=\/usr\/local\/nagios\/libexec\/check_load -w 10,8,8 -c 12,10,9$/)
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load').with({
+          'ensure'  => 'file',
+          'path'    => '/usr/local/nagios/etc/nrpe.d/check_load.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
 
-    it {
-      should contain_file('nrpe_plugin_check_me_out').with({
-        'ensure'  => 'absent',
-        'path'    => '/usr/local/nagios/etc/nrpe.d/check_me_out.cfg',
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
-        'require' => 'File[nrpe_config_dot_d]',
-        'notify'  => 'Service[nrpe_service]',
-      })
-    }
+      it {
+        should contain_file('nrpe_plugin_check_load') \
+          .with_content(/^command\[check_load\]=\/usr\/local\/nagios\/libexec\/check_load -w 10,8,8 -c 12,10,9$/)
+      }
+
+      it {
+        should contain_file('nrpe_plugin_check_me_out').with({
+          'ensure'  => 'absent',
+          'path'    => '/usr/local/nagios/etc/nrpe.d/check_me_out.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+    end
+
+    context 'with plugins_consolidate set to true' do
+      let(:params) {
+        {
+          :plugins_consolidate => 'true',
+          :plugins_consolidate_filename => 'baseline',
+          :plugins => {
+            'check_root_partition' => {
+              'plugin'     => 'check_disk',
+              'libexecdir' => '/usr/local/nagios/libexec',
+              'args'       => '-w 20% -c 10% -p /',
+            },
+            'check_load' => {
+              'args' => '-w 10,8,8 -c 12,10,9',
+            },
+            'check_me_out' => {
+              'ensure' => 'absent',
+            },
+          }
+        }
+      }
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('nrpe') }
+
+      it {
+        should contain_file('baseline').with({
+          'ensure'  => 'file',
+          'path'    => '/usr/local/nagios/etc/nrpe.d/baseline.cfg',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+          'require' => 'File[nrpe_config_dot_d]',
+          'notify'  => 'Service[nrpe_service]',
+        })
+      }
+
+      it {
+        should contain_file('baseline') \
+          .with_content(/^command\[check_root_partition\]=\/usr\/local\/nagios\/libexec\/check_disk -w 20% -c 10% -p \/$/) \
+          .with_content(/^command\[check_load\]=\/usr\/local\/nagios\/libexec\/check_load -w 10,8,8 -c 12,10,9$/) \
+          .without_content(/command\[check_me_out\]/)
+      }
+
+    end
   end
 
   context 'with plugins specified as an invalid type (array)' do

--- a/templates/consolidated.erb
+++ b/templates/consolidated.erb
@@ -1,0 +1,9 @@
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+<%if defined?(@plugins_real) -%><% @plugins_real.each do |key,value| -%>
+<% unless value['ensure'] == 'absent' -%>
+command[<%= key %>]=<% if value['libexecdir'] -%><%= value['libexecdir'] %><% else -%><%= @libexecdir_real %><% end -%>/<% if value['plugin'] -%><%= value['plugin'] %><% else -%><%= key %><% end -%><% if value['args'] -%> <%= value['args'] %><% end -%><% end -%>
+
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Two new parameters, plugins_consolidate and plugins_consolidate_filename alows the user to  consolidate all rules into one file on the client side rather than creating one file per rule.