### PR TITLE
Add command_prefix for individual plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,13 +290,21 @@ args
 ----
 Arguments to pass to the plugin.
 
-- *Defaul*: undef
+- *Default*: undef
 
 libexecdir
 ----------
 Directory in which nrpe plugin is stored.
 
 - *Default*: $nrpe::libexecdir, which is based on OS platform.
+
+command_prefix
+--------------
+Prefix an individual plugin command with a user-defined string. Must be a fully qualified path. Set to `USE_DEFAULTS` to use the value from `$nrpe::command_prefix` (defaults to `/usr/bin/sudo`).
+
+Please be careful when enabling `$nrpe::command_prefix_enable` and also setting `nrpe::plugin::command_prefix`.
+
+- *Default*: undef
 
 plugin
 ------

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -6,10 +6,11 @@
 # command[check_hda1]=@libexecdir@/check_disk -w 20% -c 10% -p /dev/hda1
 # command[$name]=$libexecdir/$plugin $args
 define nrpe::plugin (
-  $ensure     = 'present',
-  $args       = 'UNSET',
-  $libexecdir = 'USE_DEFAULTS',
-  $plugin     = 'USE_DEFAULTS',
+  $ensure         = 'present',
+  $args           = 'UNSET',
+  $libexecdir     = 'USE_DEFAULTS',
+  $plugin         = 'USE_DEFAULTS',
+  $command_prefix = 'UNSET',
 ) {
 
   validate_re($ensure,'^(present)|(absent)$',
@@ -33,6 +34,15 @@ define nrpe::plugin (
     $libexecdir_real = $nrpe::libexecdir_real
   } else {
     $libexecdir_real = $libexecdir
+  }
+
+  if $command_prefix == 'USE_DEFAULTS' {
+    $command_prefix_real = $nrpe::command_prefix
+  } elsif $command_prefix == 'UNSET' {
+    $command_prefix_real = $command_prefix
+  } else {
+    $command_prefix_real = $command_prefix
+    validate_absolute_path($command_prefix_real)
   }
 
   validate_absolute_path($libexecdir_real)

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -128,4 +128,53 @@ describe 'nrpe::plugin' do
       }.to raise_error(Puppet::Error)
     end
   end
+
+  context 'should create plugin file with no command_prefix param specified' do
+    let(:title) { 'check_disk' }
+
+    it { should compile.with_all_deps }
+
+    it { should contain_class('nrpe') }
+
+    it {
+      should contain_file('nrpe_plugin_check_disk') \
+        .with_content(/^command\[check_disk\]=\/usr\/lib64\/nagios\/plugins\/check_disk$/)
+    }
+
+    it {
+      should_not contain_file('nrpe_plugin_check_disk') \
+        .with_content(/^command\[check_disk\]=UNSET\/usr\/lib64\/nagios\/plugins\/check_disk$/)
+    }
+  end
+
+  context 'should create plugin file with command_prefix set to USE_DEFAULTS' do
+    let(:title) { 'check_disk' }
+    let(:params) { { :command_prefix => 'USE_DEFAULTS' } }
+
+    it {
+      should contain_file('nrpe_plugin_check_disk') \
+        .with_content(/^command\[check_disk\]=\/usr\/bin\/sudo \/usr\/lib64\/nagios\/plugins\/check_disk$/)
+    }
+  end
+
+  context 'should create plugin file command_prefix set to /path/to/prefix' do
+    let(:title) { 'check_disk' }
+    let(:params) { { :command_prefix => '/path/to/prefix' } }
+
+    it {
+      should contain_file('nrpe_plugin_check_disk') \
+        .with_content(/^command\[check_disk\]=\/path\/to\/prefix \/usr\/lib64\/nagios\/plugins\/check_disk$/)
+    }
+  end
+
+  context 'with command_prefix set to a non absolute path' do
+    let(:title) { 'check_disk' }
+    let(:params) { { :command_prefix => 'invalid/path' } }
+
+    it 'should fail' do
+      expect {
+        should contain_class('nrpe::plugin')
+      }.to raise_error(Puppet::Error)
+    end
+  end
 end

--- a/templates/plugin.erb
+++ b/templates/plugin.erb
@@ -1,4 +1,4 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 #
-command[<%= @name %>]=<%= @libexecdir_real %>/<%= @plugin_real %><% if @args != 'UNSET' %> <%= @args %><% end %>
+command[<%= @name %>]=<% if @command_prefix_real != 'UNSET' %><%= @command_prefix_real %> <% end %><%= @libexecdir_real %>/<%= @plugin_real %><% if @args != 'UNSET' %> <%= @args %><% end %>


### PR DESCRIPTION
Enabling ``command_prefix`` for all checks might not be favored when instead just single checks should use e.g. ``/usr/bin/sudo``. This PR allows setting ``command_prefix`` for individual checks.
 
Uses ``$nrpe::command_prefix`` if value is 'USE_DEFAULTS' and defaults to 'UNSET'.