### PR TITLE
Enable per check prefix command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class nrpe (
   $allowed_hosts                    = ['127.0.0.1'],
   $dont_blame_nrpe                  = '0',
   $allow_bash_command_substitution  = '0',
+  $check_command_prefix             = undef,
   $command_prefix_enable            = false,
   $command_prefix                   = '/usr/bin/sudo',
   $debug                            = '0',

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -6,11 +6,11 @@
 # command[check_hda1]=@libexecdir@/check_disk -w 20% -c 10% -p /dev/hda1
 # command[$name]=$libexecdir/$plugin $args
 define nrpe::plugin (
-  $ensure         = 'present',
-  $args           = 'UNSET',
-  $libexecdir     = 'USE_DEFAULTS',
-  $plugin         = 'USE_DEFAULTS',
-  $command_prefix = 'UNSET',
+  $ensure               = 'present',
+  $check_command_prefix = undef,
+  $args                 = 'UNSET',
+  $libexecdir           = 'USE_DEFAULTS',
+  $plugin               = 'USE_DEFAULTS',
 ) {
 
   validate_re($ensure,'^(present)|(absent)$',
@@ -46,6 +46,10 @@ define nrpe::plugin (
   }
 
   validate_absolute_path($libexecdir_real)
+
+  if ! ( $check_command_prefix in [ '', undef ] ) {
+    validate_absolute_path($check_command_prefix)
+  }
 
   file { "nrpe_plugin_${name}":
     ensure  => $plugin_ensure,

--- a/templates/plugin.erb
+++ b/templates/plugin.erb
@@ -1,4 +1,4 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 #
-command[<%= @name %>]=<% if @command_prefix_real != 'UNSET' %><%= @command_prefix_real %> <% end %><%= @libexecdir_real %>/<%= @plugin_real %><% if @args != 'UNSET' %> <%= @args %><% end %>
+command[<%= @name %>]=<% unless @check_command_prefix.nil? %><%= @check_command_prefix %> <% end %><%= @libexecdir_real %>/<%= @plugin_real %><% if @args != 'UNSET' %> <%= @args %><% end %>


### PR DESCRIPTION
In the configuation file it's "all or nothing", for the prefix command.
This is not what we want, we want the ability to use a prefix per check.

I do the pull request, code is mostly by *Wilmar Theunissen @ SIDN*