### PR TITLE
Add support for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ It is tested on the following platforms.
 * Solaris 10
 * Solaris 11
 * Ubuntu 12
+* Ubuntu 14.04
+* Ubuntu 16.04
+* Ubuntu 18.04
+* Ubuntu 20.04
 
 ===
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,7 +116,10 @@ class nrpe (
           $default_nrpe_package                     = 'nagios-nrpe-server'
           $default_nrpe_package_adminfile           = undef
           $default_nrpe_package_source              = undef
-          $default_nagios_plugins_package           = 'nagios-plugins-basic'
+          $default_nagios_plugins_package           = (versioncmp($facts[os][release][full], '20.04') < 0) ? {
+            true    => 'nagios-plugins-basic',
+            default => 'monitoring-plugins-basic',
+          }
           $default_nagios_plugins_package_adminfile = undef
           $default_nagios_plugins_package_source    = undef
           $default_nrpe_config                      = '/etc/nagios/nrpe.cfg'

--- a/metadata.json
+++ b/metadata.json
@@ -62,7 +62,11 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04"
+        "12.04",
+        "14.04",
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     }
   ]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -333,7 +333,7 @@ describe 'nrpe' do
     }
   end
 
-  context 'with default options on Ubuntu' do
+  context 'with default options on Ubuntu 12' do
     let(:facts) do
       { :osfamily          => 'Debian',
         :lsbdistid         => 'Ubuntu',
@@ -355,6 +355,322 @@ describe 'nrpe' do
 
     it {
       should contain_package('nagios-plugins-basic').with({
+        'ensure'    => 'present',
+        'adminfile' => nil,
+        'source'    => nil,
+        'before'    => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_config').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Package[nagios-nrpe-server]',
+      })
+    }
+
+    it { should contain_file('nrpe_config').with_content(/^log_facility=daemon$/) }
+    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nagios\/nrpe.pid$/) }
+    it { should contain_file('nrpe_config').with_content(/^server_port=5666$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^server_address=127.0.0.1$/) }
+    it { should contain_file('nrpe_config').with_content(/^nrpe_user=nagios$/) }
+    it { should contain_file('nrpe_config').with_content(/^nrpe_group=nagios$/) }
+    it { should contain_file('nrpe_config').with_content(/^allowed_hosts=127.0.0.1$/) }
+    it { should contain_file('nrpe_config').with_content(/^dont_blame_nrpe=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^allow_bash_command_substitution=0$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^command_prefix=\/usr\/bin\/sudo$/) }
+    it { should contain_file('nrpe_config').with_content(/^debug=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^command_timeout=60$/) }
+    it { should contain_file('nrpe_config').with_content(/^connection_timeout=300$/) }
+    it { should contain_file('nrpe_config').with_content(/^allow_weak_random_seed=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^include_dir=\/etc\/nagios\/nrpe.d$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^command\[$/) }
+
+    it {
+      should contain_file('nrpe_config_dot_d').with({
+        'ensure'  => 'directory',
+        'path'    => '/etc/nagios/nrpe.d',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Package[nagios-nrpe-server]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_service('nrpe_service').with({
+        'ensure'    => 'running',
+        'name'      => 'nagios-nrpe-server',
+        'enable'    => true,
+        'subscribe' => 'File[nrpe_config]',
+      })
+    }
+  end
+
+  context 'with default options on Ubuntu 14.04' do
+    let(:facts) do
+      { :osfamily          => 'Debian',
+        :lsbdistid         => 'Ubuntu',
+        :lsbmajdistrelease => '14.04',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_class('nrpe') }
+
+    it {
+      should contain_package('nagios-nrpe-server').with({
+        'ensure'    => 'present',
+        'adminfile' => nil,
+        'source'    => nil,
+      })
+    }
+
+    it {
+      should contain_package('nagios-plugins-basic').with({
+        'ensure'    => 'present',
+        'adminfile' => nil,
+        'source'    => nil,
+        'before'    => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_config').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Package[nagios-nrpe-server]',
+      })
+    }
+
+    it { should contain_file('nrpe_config').with_content(/^log_facility=daemon$/) }
+    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nagios\/nrpe.pid$/) }
+    it { should contain_file('nrpe_config').with_content(/^server_port=5666$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^server_address=127.0.0.1$/) }
+    it { should contain_file('nrpe_config').with_content(/^nrpe_user=nagios$/) }
+    it { should contain_file('nrpe_config').with_content(/^nrpe_group=nagios$/) }
+    it { should contain_file('nrpe_config').with_content(/^allowed_hosts=127.0.0.1$/) }
+    it { should contain_file('nrpe_config').with_content(/^dont_blame_nrpe=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^allow_bash_command_substitution=0$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^command_prefix=\/usr\/bin\/sudo$/) }
+    it { should contain_file('nrpe_config').with_content(/^debug=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^command_timeout=60$/) }
+    it { should contain_file('nrpe_config').with_content(/^connection_timeout=300$/) }
+    it { should contain_file('nrpe_config').with_content(/^allow_weak_random_seed=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^include_dir=\/etc\/nagios\/nrpe.d$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^command\[$/) }
+
+    it {
+      should contain_file('nrpe_config_dot_d').with({
+        'ensure'  => 'directory',
+        'path'    => '/etc/nagios/nrpe.d',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Package[nagios-nrpe-server]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_service('nrpe_service').with({
+        'ensure'    => 'running',
+        'name'      => 'nagios-nrpe-server',
+        'enable'    => true,
+        'subscribe' => 'File[nrpe_config]',
+      })
+    }
+  end
+
+  context 'with default options on Ubuntu 16.04' do
+    let(:facts) do
+      { :osfamily          => 'Debian',
+        :lsbdistid         => 'Ubuntu',
+        :lsbmajdistrelease => '16.04',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_class('nrpe') }
+
+    it {
+      should contain_package('nagios-nrpe-server').with({
+        'ensure'    => 'present',
+        'adminfile' => nil,
+        'source'    => nil,
+      })
+    }
+
+    it {
+      should contain_package('nagios-plugins-basic').with({
+        'ensure'    => 'present',
+        'adminfile' => nil,
+        'source'    => nil,
+        'before'    => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_config').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Package[nagios-nrpe-server]',
+      })
+    }
+
+    it { should contain_file('nrpe_config').with_content(/^log_facility=daemon$/) }
+    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nagios\/nrpe.pid$/) }
+    it { should contain_file('nrpe_config').with_content(/^server_port=5666$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^server_address=127.0.0.1$/) }
+    it { should contain_file('nrpe_config').with_content(/^nrpe_user=nagios$/) }
+    it { should contain_file('nrpe_config').with_content(/^nrpe_group=nagios$/) }
+    it { should contain_file('nrpe_config').with_content(/^allowed_hosts=127.0.0.1$/) }
+    it { should contain_file('nrpe_config').with_content(/^dont_blame_nrpe=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^allow_bash_command_substitution=0$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^command_prefix=\/usr\/bin\/sudo$/) }
+    it { should contain_file('nrpe_config').with_content(/^debug=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^command_timeout=60$/) }
+    it { should contain_file('nrpe_config').with_content(/^connection_timeout=300$/) }
+    it { should contain_file('nrpe_config').with_content(/^allow_weak_random_seed=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^include_dir=\/etc\/nagios\/nrpe.d$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^command\[$/) }
+
+    it {
+      should contain_file('nrpe_config_dot_d').with({
+        'ensure'  => 'directory',
+        'path'    => '/etc/nagios/nrpe.d',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Package[nagios-nrpe-server]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_service('nrpe_service').with({
+        'ensure'    => 'running',
+        'name'      => 'nagios-nrpe-server',
+        'enable'    => true,
+        'subscribe' => 'File[nrpe_config]',
+      })
+    }
+  end
+
+  context 'with default options on Ubuntu 18.04' do
+    let(:facts) do
+      { :osfamily          => 'Debian',
+        :lsbdistid         => 'Ubuntu',
+        :lsbmajdistrelease => '18.04',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_class('nrpe') }
+
+    it {
+      should contain_package('nagios-nrpe-server').with({
+        'ensure'    => 'present',
+        'adminfile' => nil,
+        'source'    => nil,
+      })
+    }
+
+    it {
+      should contain_package('nagios-plugins-basic').with({
+        'ensure'    => 'present',
+        'adminfile' => nil,
+        'source'    => nil,
+        'before'    => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_config').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Package[nagios-nrpe-server]',
+      })
+    }
+
+    it { should contain_file('nrpe_config').with_content(/^log_facility=daemon$/) }
+    it { should contain_file('nrpe_config').with_content(/^pid_file=\/var\/run\/nagios\/nrpe.pid$/) }
+    it { should contain_file('nrpe_config').with_content(/^server_port=5666$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^server_address=127.0.0.1$/) }
+    it { should contain_file('nrpe_config').with_content(/^nrpe_user=nagios$/) }
+    it { should contain_file('nrpe_config').with_content(/^nrpe_group=nagios$/) }
+    it { should contain_file('nrpe_config').with_content(/^allowed_hosts=127.0.0.1$/) }
+    it { should contain_file('nrpe_config').with_content(/^dont_blame_nrpe=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^allow_bash_command_substitution=0$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^command_prefix=\/usr\/bin\/sudo$/) }
+    it { should contain_file('nrpe_config').with_content(/^debug=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^command_timeout=60$/) }
+    it { should contain_file('nrpe_config').with_content(/^connection_timeout=300$/) }
+    it { should contain_file('nrpe_config').with_content(/^allow_weak_random_seed=0$/) }
+    it { should contain_file('nrpe_config').with_content(/^include_dir=\/etc\/nagios\/nrpe.d$/) }
+    it { should_not contain_file('nrpe_config').with_content(/^command\[$/) }
+
+    it {
+      should contain_file('nrpe_config_dot_d').with({
+        'ensure'  => 'directory',
+        'path'    => '/etc/nagios/nrpe.d',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Package[nagios-nrpe-server]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_service('nrpe_service').with({
+        'ensure'    => 'running',
+        'name'      => 'nagios-nrpe-server',
+        'enable'    => true,
+        'subscribe' => 'File[nrpe_config]',
+      })
+    }
+  end
+
+  context 'with default options on Ubuntu 20.04' do
+    let(:facts) do
+      { :osfamily          => 'Debian',
+        :lsbdistid         => 'Ubuntu',
+        :lsbmajdistrelease => '20.04',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_class('nrpe') }
+
+    it {
+      should contain_package('nagios-nrpe-server').with({
+        'ensure'    => 'present',
+        'adminfile' => nil,
+        'source'    => nil,
+      })
+    }
+
+    it {
+      should contain_package('monitoring-plugins-basic').with({
         'ensure'    => 'present',
         'adminfile' => nil,
         'source'    => nil,
@@ -1030,6 +1346,310 @@ describe 'nrpe' do
       { :osfamily          => 'Debian',
         :lsbdistid         => 'Ubuntu',
         :lsbmajdistrelease => '12',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_class('nrpe') }
+
+    it {
+      should contain_file('nrpe_plugin_check_root_partition').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.d/check_root_partition.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_root_partition') \
+        .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_load').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.d/check_load.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_load') \
+        .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_me_out').with({
+        'ensure'  => 'absent',
+        'path'    => '/etc/nagios/nrpe.d/check_me_out.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+  end
+
+  context 'with plugins specified as a hash on Ubuntu 14.04' do
+    let(:params) {
+      {
+        :plugins => {
+          'check_root_partition' => {
+            'plugin'     => 'check_disk',
+            'libexecdir' => '/usr/lib/nagios/plugins',
+            'args'       => '-w 20% -c 10% -p /',
+          },
+          'check_load' => {
+            'args'       => '-w 10,8,8 -c 12,10,9',
+          },
+          'check_me_out' => {
+            'ensure' => 'absent',
+          },
+        }
+      }
+    }
+    let(:facts) do
+      { :osfamily          => 'Debian',
+        :lsbdistid         => 'Ubuntu',
+        :lsbmajdistrelease => '14.04',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_class('nrpe') }
+
+    it {
+      should contain_file('nrpe_plugin_check_root_partition').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.d/check_root_partition.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_root_partition') \
+        .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_load').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.d/check_load.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_load') \
+        .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_me_out').with({
+        'ensure'  => 'absent',
+        'path'    => '/etc/nagios/nrpe.d/check_me_out.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+  end
+
+  context 'with plugins specified as a hash on Ubuntu 16.04' do
+    let(:params) {
+      {
+        :plugins => {
+          'check_root_partition' => {
+            'plugin'     => 'check_disk',
+            'libexecdir' => '/usr/lib/nagios/plugins',
+            'args'       => '-w 20% -c 10% -p /',
+          },
+          'check_load' => {
+            'args'       => '-w 10,8,8 -c 12,10,9',
+          },
+          'check_me_out' => {
+            'ensure' => 'absent',
+          },
+        }
+      }
+    }
+    let(:facts) do
+      { :osfamily          => 'Debian',
+        :lsbdistid         => 'Ubuntu',
+        :lsbmajdistrelease => '16.04',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_class('nrpe') }
+
+    it {
+      should contain_file('nrpe_plugin_check_root_partition').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.d/check_root_partition.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_root_partition') \
+        .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_load').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.d/check_load.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_load') \
+        .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_me_out').with({
+        'ensure'  => 'absent',
+        'path'    => '/etc/nagios/nrpe.d/check_me_out.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+  end
+
+  context 'with plugins specified as a hash on Ubuntu 18.04' do
+    let(:params) {
+      {
+        :plugins => {
+          'check_root_partition' => {
+            'plugin'     => 'check_disk',
+            'libexecdir' => '/usr/lib/nagios/plugins',
+            'args'       => '-w 20% -c 10% -p /',
+          },
+          'check_load' => {
+            'args'       => '-w 10,8,8 -c 12,10,9',
+          },
+          'check_me_out' => {
+            'ensure' => 'absent',
+          },
+        }
+      }
+    }
+    let(:facts) do
+      { :osfamily          => 'Debian',
+        :lsbdistid         => 'Ubuntu',
+        :lsbmajdistrelease => '18.04',
+      }
+    end
+
+    it { should compile.with_all_deps }
+
+    it { should contain_class('nrpe') }
+
+    it {
+      should contain_file('nrpe_plugin_check_root_partition').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.d/check_root_partition.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_root_partition') \
+        .with_content(/^command\[check_root_partition\]=\/usr\/lib\/nagios\/plugins\/check_disk -w 20% -c 10% -p \/$/)
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_load').with({
+        'ensure'  => 'file',
+        'path'    => '/etc/nagios/nrpe.d/check_load.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_load') \
+        .with_content(/^command\[check_load\]=\/usr\/lib\/nagios\/plugins\/check_load -w 10,8,8 -c 12,10,9$/)
+    }
+
+    it {
+      should contain_file('nrpe_plugin_check_me_out').with({
+        'ensure'  => 'absent',
+        'path'    => '/etc/nagios/nrpe.d/check_me_out.cfg',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'File[nrpe_config_dot_d]',
+        'notify'  => 'Service[nrpe_service]',
+      })
+    }
+  end
+
+  context 'with plugins specified as a hash on Ubuntu 20.04' do
+    let(:params) {
+      {
+        :plugins => {
+          'check_root_partition' => {
+            'plugin'     => 'check_disk',
+            'libexecdir' => '/usr/lib/nagios/plugins',
+            'args'       => '-w 20% -c 10% -p /',
+          },
+          'check_load' => {
+            'args'       => '-w 10,8,8 -c 12,10,9',
+          },
+          'check_me_out' => {
+            'ensure' => 'absent',
+          },
+        }
+      }
+    }
+    let(:facts) do
+      { :osfamily          => 'Debian',
+        :lsbdistid         => 'Ubuntu',
+        :lsbmajdistrelease => '20.04',
       }
     end
 


### PR DESCRIPTION
Since Ubuntu 16.04 the plugins package is `monitoring-plugins-basic` but
a metapackage named `nagios-plugins-basic` (which install the former) is
maintained. In Ubuntu 20.04 this metapackage does not exist.